### PR TITLE
Set Travis branch and email notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,15 @@ script:
   - bundle exec rake db:schema:load
   - bundle exec rake db:test:prepare
   - bundle exec rake
+branches:
+  only:
+    - master
+notifications:
+  email:
+    recipients:
+      - darryqueen@berkeley.edu
+      - edwhang@berkeley.edu
+      - bwasmith@berkeley.edu
+      - nalnaji@berkeley.edu
+      - nishadsingh@berkeley.edu
+      - jshum@berkeley.edu


### PR DESCRIPTION
Only builds for master branch, to avoid spammy emails.
Also sets notification emails for when build fails.

Note: I'm using everyone's Berkeley emails; let me know if you use a different email for your Github account so you don't get two emails.

Reviewer: @nalnaji