### PR TITLE
Set up email confirmations.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem 'rails_admin', :git => 'git://github.com/sferik/rails_admin.git', :branch =>
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 
+gem 'roadie'
+gem 'roadie-rails'
+
 # Handle API secrets:
 gem 'figaro'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       multi_json (~> 1.0)
     acts-as-taggable-on (3.5.0)
       activerecord (>= 3.2, < 5)
+    addressable (2.3.7)
     arel (3.0.3)
     bcrypt (3.1.10)
     bootstrap-sass (2.3.2.2)
@@ -70,6 +71,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    css_parser (1.3.6)
+      addressable
     cucumber (1.3.19)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -190,6 +193,12 @@ GEM
     remotipart (1.2.1)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
+    roadie (3.0.4)
+      css_parser (~> 1.3.4)
+      nokogiri (~> 1.6.0)
+    roadie-rails (1.0.5)
+      railties (>= 3.0, < 4.3)
+      roadie (~> 3.0)
     rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -254,6 +263,8 @@ DEPENDENCIES
   rails3-jquery-autocomplete
   rails_admin!
   rake
+  roadie
+  roadie-rails
   rspec-rails (~> 2.14.0)
   sass-rails (~> 3.2.3)
   simplecov

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,4 +14,5 @@
  *= require bootstrap.min
  *= require bootstrap-social.min
  *= require font-awesome.min
+ *= stub bootstrap-email.min
  */

--- a/app/assets/stylesheets/bootstrap-email.min.css
+++ b/app/assets/stylesheets/bootstrap-email.min.css
@@ -1,0 +1,596 @@
+/*!
+ * Bootstrap v2.1.1
+ *
+ * Copyright 2012 Twitter, Inc
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ */article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
+audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
+audio:not([controls]){display:none}
+html{font-size:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}
+a:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
+a:hover,a:active{outline:0}
+sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}
+sup{top:-0.5em}
+sub{bottom:-0.25em}
+img{max-width:100%;width:auto\9;height:auto;vertical-align:middle;border:0;-ms-interpolation-mode:bicubic}
+#map_canvas img{max-width:none}
+button,input,select,textarea{margin:0;font-size:100%;vertical-align:middle}
+button,input{*overflow:visible;line-height:normal}
+button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}
+button,input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button}
+input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}
+input[type="search"]::-webkit-search-decoration,input[type="search"]::-webkit-search-cancel-button{-webkit-appearance:none}
+textarea{overflow:auto;vertical-align:top}
+.clearfix{*zoom:1}
+.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+body{margin:0;font-family:"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;color:#333;background-color:#fff}
+a{color:#0063ca;text-decoration:none}
+a:hover{color:#003e7e;text-decoration:underline}
+.img-rounded{-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}
+.img-polaroid{padding:4px;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.1);-moz-box-shadow:0 1px 3px rgba(0,0,0,0.1);box-shadow:0 1px 3px rgba(0,0,0,0.1)}
+.img-circle{-webkit-border-radius:500px;-moz-border-radius:500px;border-radius:500px}
+.row{margin-left:-20px;*zoom:1}
+.row:before,.row:after{display:table;content:"";line-height:0}
+.row:after{clear:both}
+[class*="span"]{float:left;min-height:1px;margin-left:20px}
+.container,.navbar-static-top .container,.navbar-fixed-top .container,.navbar-fixed-bottom .container{width:940px}
+.span12{width:940px}
+.span11{width:860px}
+.span10{width:780px}
+.span9{width:700px}
+.span8{width:620px}
+.span7{width:540px}
+.span6{width:460px}
+.span5{width:380px}
+.span4{width:300px}
+.span3{width:220px}
+.span2{width:140px}
+.span1{width:60px}
+.offset12{margin-left:980px}
+.offset11{margin-left:900px}
+.offset10{margin-left:820px}
+.offset9{margin-left:740px}
+.offset8{margin-left:660px}
+.offset7{margin-left:580px}
+.offset6{margin-left:500px}
+.offset5{margin-left:420px}
+.offset4{margin-left:340px}
+.offset3{margin-left:260px}
+.offset2{margin-left:180px}
+.offset1{margin-left:100px}
+.row-fluid{width:100%;*zoom:1}
+.row-fluid:before,.row-fluid:after{display:table;content:"";line-height:0}
+.row-fluid:after{clear:both}
+.row-fluid [class*="span"]{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;float:left;margin-left:2.127659574468085%;*margin-left:2.074468085106383%}
+.row-fluid [class*="span"]:first-child{margin-left:0}
+.row-fluid .span12{width:100%;*width:99.94680851063829%}
+.row-fluid .span11{width:91.48936170212765%;*width:91.43617021276594%}
+.row-fluid .span10{width:82.97872340425532%;*width:82.92553191489361%}
+.row-fluid .span9{width:74.46808510638297%;*width:74.41489361702126%}
+.row-fluid .span8{width:65.95744680851064%;*width:65.90425531914893%}
+.row-fluid .span7{width:57.44680851063829%;*width:57.39361702127659%}
+.row-fluid .span6{width:48.93617021276595%;*width:48.88297872340425%}
+.row-fluid .span5{width:40.42553191489362%;*width:40.37234042553192%}
+.row-fluid .span4{width:31.914893617021278%;*width:31.861702127659576%}
+.row-fluid .span3{width:23.404255319148934%;*width:23.351063829787233%}
+.row-fluid .span2{width:14.893617021276595%;*width:14.840425531914894%}
+.row-fluid .span1{width:6.382978723404255%;*width:6.329787234042553%}
+.row-fluid .offset12{margin-left:104.25531914893617%;*margin-left:104.14893617021275%}
+.row-fluid .offset12:first-child{margin-left:102.12765957446808%;*margin-left:102.02127659574467%}
+.row-fluid .offset11{margin-left:95.74468085106382%;*margin-left:95.6382978723404%}
+.row-fluid .offset11:first-child{margin-left:93.61702127659574%;*margin-left:93.51063829787232%}
+.row-fluid .offset10{margin-left:87.23404255319149%;*margin-left:87.12765957446807%}
+.row-fluid .offset10:first-child{margin-left:85.1063829787234%;*margin-left:84.99999999999999%}
+.row-fluid .offset9{margin-left:78.72340425531914%;*margin-left:78.61702127659572%}
+.row-fluid .offset9:first-child{margin-left:76.59574468085106%;*margin-left:76.48936170212764%}
+.row-fluid .offset8{margin-left:70.2127659574468%;*margin-left:70.10638297872339%}
+.row-fluid .offset8:first-child{margin-left:68.08510638297872%;*margin-left:67.9787234042553%}
+.row-fluid .offset7{margin-left:61.70212765957446%;*margin-left:61.59574468085106%}
+.row-fluid .offset7:first-child{margin-left:59.574468085106375%;*margin-left:59.46808510638297%}
+.row-fluid .offset6{margin-left:53.191489361702125%;*margin-left:53.085106382978715%}
+.row-fluid .offset6:first-child{margin-left:51.063829787234035%;*margin-left:50.95744680851063%}
+.row-fluid .offset5{margin-left:44.68085106382979%;*margin-left:44.57446808510638%}
+.row-fluid .offset5:first-child{margin-left:42.5531914893617%;*margin-left:42.4468085106383%}
+.row-fluid .offset4{margin-left:36.170212765957444%;*margin-left:36.06382978723405%}
+.row-fluid .offset4:first-child{margin-left:34.04255319148936%;*margin-left:33.93617021276596%}
+.row-fluid .offset3{margin-left:27.659574468085104%;*margin-left:27.5531914893617%}
+.row-fluid .offset3:first-child{margin-left:25.53191489361702%;*margin-left:25.425531914893618%}
+.row-fluid .offset2{margin-left:19.148936170212764%;*margin-left:19.04255319148936%}
+.row-fluid .offset2:first-child{margin-left:17.02127659574468%;*margin-left:16.914893617021278%}
+.row-fluid .offset1{margin-left:10.638297872340425%;*margin-left:10.53191489361702%}
+.row-fluid .offset1:first-child{margin-left:8.51063829787234%;*margin-left:8.404255319148938%}
+[class*="span"].hide,.row-fluid [class*="span"].hide{display:none}
+[class*="span"].pull-right,.row-fluid [class*="span"].pull-right{float:right}
+.container{margin-right:auto;margin-left:auto;*zoom:1}
+.container:before,.container:after{display:table;content:"";line-height:0}
+.container:after{clear:both}
+.container-fluid{padding-right:20px;padding-left:20px;*zoom:1}
+.container-fluid:before,.container-fluid:after{display:table;content:"";line-height:0}
+.container-fluid:after{clear:both}
+p{margin:0 0 10px}
+.lead{margin-bottom:20px;font-size:19.5px;font-weight:200;line-height:30px}
+small{font-size:85%}
+strong{font-weight:bold}
+em{font-style:italic}
+cite{font-style:normal}
+.muted{color:#999}
+.text-warning{color:#c09853}
+.text-error{color:#b94a48}
+.text-info{color:#3a87ad}
+.text-success{color:#468847}
+h1,h2,h3,h4,h5,h6{margin:10px 0;font-family:inherit;font-weight:bold;line-height:1;color:inherit;text-rendering:optimizelegibility}
+h1 small,h2 small,h3 small,h4 small,h5 small,h6 small{font-weight:normal;line-height:1;color:#999}
+h1{font-size:36px;line-height:40px}
+h2{font-size:30px;line-height:40px}
+h3{font-size:24px;line-height:40px}
+h4{font-size:18px;line-height:20px}
+h5{font-size:14px;line-height:20px}
+h6{font-size:12px;line-height:20px}
+h1 small{font-size:24px}
+h2 small{font-size:18px}
+h3 small{font-size:14px}
+h4 small{font-size:14px}
+.page-header{padding-bottom:9px;margin:20px 0 30px;border-bottom:1px solid #eee}
+ul,ol{padding:0;margin:0 0 10px 25px}
+ul ul,ul ol,ol ol,ol ul{margin-bottom:0}
+li{line-height:20px}
+ul.unstyled,ol.unstyled{margin-left:0;list-style:none}
+dl{margin-bottom:20px}
+dt,dd{line-height:20px}
+dt{font-weight:bold}
+dd{margin-left:10px}
+.dl-horizontal{*zoom:1}
+.dl-horizontal:before,.dl-horizontal:after{display:table;content:"";line-height:0}
+.dl-horizontal:after{clear:both}
+.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dl-horizontal dd{margin-left:180px}
+hr{margin:20px 0;border:0;border-top:1px solid #eee;border-bottom:1px solid #fff}
+abbr[title]{cursor:help;border-bottom:1px dotted #999}
+abbr.initialism{font-size:90%;text-transform:uppercase}
+blockquote{padding:0 0 0 15px;margin:0 0 20px;border-left:5px solid #eee}
+blockquote p{margin-bottom:0;font-size:16px;font-weight:300;line-height:25px}
+blockquote small{display:block;line-height:20px;color:#999}
+blockquote small:before{content:'\2014 \00A0'}
+blockquote.pull-right{float:right;padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0}
+blockquote.pull-right p,blockquote.pull-right small{text-align:right}
+blockquote.pull-right small:before{content:''}
+blockquote.pull-right small:after{content:'\00A0 \2014'}
+q:before,q:after,blockquote:before,blockquote:after{content:""}
+address{display:block;margin-bottom:20px;font-style:normal;line-height:20px}
+code,pre{padding:0 3px 2px;font-family:Monaco,Menlo,Consolas,"Courier New",monospace;font-size:11px;color:#333;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}
+code{padding:2px 4px;color:#d14;background-color:#f7f7f9;border:1px solid #e1e1e8}
+pre{display:block;padding:9.5px;margin:0 0 10px;font-size:12px;line-height:20px;word-break:break-all;word-wrap:break-word;white-space:pre;white-space:pre-wrap;background-color:#f5f5f5;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}
+pre.prettyprint{margin-bottom:20px}
+pre code{padding:0;color:inherit;background-color:transparent;border:0}
+.pre-scrollable{max-height:340px;overflow-y:scroll}
+table{max-width:100%;background-color:transparent;border-collapse:collapse;border-spacing:0}
+.table{width:100%;margin-bottom:20px}
+.table th,.table td{padding:8px;line-height:20px;text-align:left;vertical-align:top;border-top:1px solid #ddd}
+.table th{font-weight:bold}
+.table thead th{vertical-align:bottom}
+.table caption+thead tr:first-child th,.table caption+thead tr:first-child td,.table colgroup+thead tr:first-child th,.table colgroup+thead tr:first-child td,.table thead:first-child tr:first-child th,.table thead:first-child tr:first-child td{border-top:0}
+.table tbody+tbody{border-top:2px solid #ddd}
+.table-condensed th,.table-condensed td{padding:4px 5px}
+.table-bordered{border:1px solid #ddd;border-collapse:separate;*border-collapse:collapse;border-left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}
+.table-bordered th,.table-bordered td{border-left:1px solid #ddd}
+.table-bordered caption+thead tr:first-child th,.table-bordered caption+tbody tr:first-child th,.table-bordered caption+tbody tr:first-child td,.table-bordered colgroup+thead tr:first-child th,.table-bordered colgroup+tbody tr:first-child th,.table-bordered colgroup+tbody tr:first-child td,.table-bordered thead:first-child tr:first-child th,.table-bordered tbody:first-child tr:first-child th,.table-bordered tbody:first-child tr:first-child td{border-top:0}
+.table-bordered thead:first-child tr:first-child th:first-child,.table-bordered tbody:first-child tr:first-child td:first-child{-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-topleft:4px}
+.table-bordered thead:first-child tr:first-child th:last-child,.table-bordered tbody:first-child tr:first-child td:last-child{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-moz-border-radius-topright:4px}
+.table-bordered thead:last-child tr:last-child th:first-child,.table-bordered tbody:last-child tr:last-child td:first-child,.table-bordered tfoot:last-child tr:last-child td:first-child{-webkit-border-radius:0 0 0 4px;-moz-border-radius:0 0 0 4px;border-radius:0 0 0 4px;-webkit-border-bottom-left-radius:4px;border-bottom-left-radius:4px;-moz-border-radius-bottomleft:4px}
+.table-bordered thead:last-child tr:last-child th:last-child,.table-bordered tbody:last-child tr:last-child td:last-child,.table-bordered tfoot:last-child tr:last-child td:last-child{-webkit-border-bottom-right-radius:4px;border-bottom-right-radius:4px;-moz-border-radius-bottomright:4px}
+.table-bordered caption+thead tr:first-child th:first-child,.table-bordered caption+tbody tr:first-child td:first-child,.table-bordered colgroup+thead tr:first-child th:first-child,.table-bordered colgroup+tbody tr:first-child td:first-child{-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-topleft:4px}
+.table-bordered caption+thead tr:first-child th:last-child,.table-bordered caption+tbody tr:first-child td:last-child,.table-bordered colgroup+thead tr:first-child th:last-child,.table-bordered colgroup+tbody tr:first-child td:last-child{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-moz-border-radius-topleft:4px}
+.table-striped tbody tr:nth-child(odd) td,.table-striped tbody tr:nth-child(odd) th{background-color:#f9f9f9}
+.table-hover tbody tr:hover td,.table-hover tbody tr:hover th{background-color:#f5f5f5}
+table [class*=span],.row-fluid table [class*=span]{display:table-cell;float:none;margin-left:0}
+.table .span1{float:none;width:44px;margin-left:0}
+.table .span2{float:none;width:124px;margin-left:0}
+.table .span3{float:none;width:204px;margin-left:0}
+.table .span4{float:none;width:284px;margin-left:0}
+.table .span5{float:none;width:364px;margin-left:0}
+.table .span6{float:none;width:444px;margin-left:0}
+.table .span7{float:none;width:524px;margin-left:0}
+.table .span8{float:none;width:604px;margin-left:0}
+.table .span9{float:none;width:684px;margin-left:0}
+.table .span10{float:none;width:764px;margin-left:0}
+.table .span11{float:none;width:844px;margin-left:0}
+.table .span12{float:none;width:924px;margin-left:0}
+.table .span13{float:none;width:1004px;margin-left:0}
+.table .span14{float:none;width:1084px;margin-left:0}
+.table .span15{float:none;width:1164px;margin-left:0}
+.table .span16{float:none;width:1244px;margin-left:0}
+.table .span17{float:none;width:1324px;margin-left:0}
+.table .span18{float:none;width:1404px;margin-left:0}
+.table .span19{float:none;width:1484px;margin-left:0}
+.table .span20{float:none;width:1564px;margin-left:0}
+.table .span21{float:none;width:1644px;margin-left:0}
+.table .span22{float:none;width:1724px;margin-left:0}
+.table .span23{float:none;width:1804px;margin-left:0}
+.table .span24{float:none;width:1884px;margin-left:0}
+.table tbody tr.success td{background-color:#dff0d8}
+.table tbody tr.error td{background-color:#f2dede}
+.table tbody tr.warning td{background-color:#fcf8e3}
+.table tbody tr.info td{background-color:#d9edf7}
+.table-hover tbody tr.success:hover td{background-color:#d0e9c6}
+.table-hover tbody tr.error:hover td{background-color:#ebcccc}
+.table-hover tbody tr.warning:hover td{background-color:#faf2cc}
+.table-hover tbody tr.info:hover td{background-color:#c4e3f3}
+[class^="icon-"],[class*=" icon-"]{display:inline-block;width:14px;height:14px;*margin-right:.3em;line-height:14px;vertical-align:text-top;background-image:url("https://az340737.vo.msecnd.net/resources/glyphicons-halflings.png");background-position:14px 14px;background-repeat:no-repeat;margin-top:1px}
+.icon-white,.nav-tabs>.active>a>[class^="icon-"],.nav-tabs>.active>a>[class*=" icon-"],.nav-pills>.active>a>[class^="icon-"],.nav-pills>.active>a>[class*=" icon-"],.nav-list>.active>a>[class^="icon-"],.nav-list>.active>a>[class*=" icon-"],.navbar-inverse .nav>.active>a>[class^="icon-"],.navbar-inverse .nav>.active>a>[class*=" icon-"],.dropdown-menu>li>a:hover>[class^="icon-"],.dropdown-menu>li>a:hover>[class*=" icon-"],.dropdown-menu>.active>a>[class^="icon-"],.dropdown-menu>.active>a>[class*=" icon-"]{background-image:url("https://az340737.vo.msecnd.net/resources/glyphicons-halflings-white.png")}
+.icon-glass{background-position:0 0}
+.icon-music{background-position:-24px 0}
+.icon-search{background-position:-48px 0}
+.icon-envelope{background-position:-72px 0}
+.icon-heart{background-position:-96px 0}
+.icon-star{background-position:-120px 0}
+.icon-star-empty{background-position:-144px 0}
+.icon-user{background-position:-168px 0}
+.icon-film{background-position:-192px 0}
+.icon-th-large{background-position:-216px 0}
+.icon-th{background-position:-240px 0}
+.icon-th-list{background-position:-264px 0}
+.icon-ok{background-position:-288px 0}
+.icon-remove{background-position:-312px 0}
+.icon-zoom-in{background-position:-336px 0}
+.icon-zoom-out{background-position:-360px 0}
+.icon-off{background-position:-384px 0}
+.icon-signal{background-position:-408px 0}
+.icon-cog{background-position:-432px 0}
+.icon-trash{background-position:-456px 0}
+.icon-home{background-position:0 -24px}
+.icon-file{background-position:-24px -24px}
+.icon-time{background-position:-48px -24px}
+.icon-road{background-position:-72px -24px}
+.icon-download-alt{background-position:-96px -24px}
+.icon-download{background-position:-120px -24px}
+.icon-upload{background-position:-144px -24px}
+.icon-inbox{background-position:-168px -24px}
+.icon-play-circle{background-position:-192px -24px}
+.icon-repeat{background-position:-216px -24px}
+.icon-refresh{background-position:-240px -24px}
+.icon-list-alt{background-position:-264px -24px}
+.icon-lock{background-position:-287px -24px}
+.icon-flag{background-position:-312px -24px}
+.icon-headphones{background-position:-336px -24px}
+.icon-volume-off{background-position:-360px -24px}
+.icon-volume-down{background-position:-384px -24px}
+.icon-volume-up{background-position:-408px -24px}
+.icon-qrcode{background-position:-432px -24px}
+.icon-barcode{background-position:-456px -24px}
+.icon-tag{background-position:0 -48px}
+.icon-tags{background-position:-25px -48px}
+.icon-book{background-position:-48px -48px}
+.icon-bookmark{background-position:-72px -48px}
+.icon-print{background-position:-96px -48px}
+.icon-camera{background-position:-120px -48px}
+.icon-font{background-position:-144px -48px}
+.icon-bold{background-position:-167px -48px}
+.icon-italic{background-position:-192px -48px}
+.icon-text-height{background-position:-216px -48px}
+.icon-text-width{background-position:-240px -48px}
+.icon-align-left{background-position:-264px -48px}
+.icon-align-center{background-position:-288px -48px}
+.icon-align-right{background-position:-312px -48px}
+.icon-align-justify{background-position:-336px -48px}
+.icon-list{background-position:-360px -48px}
+.icon-indent-left{background-position:-384px -48px}
+.icon-indent-right{background-position:-408px -48px}
+.icon-facetime-video{background-position:-432px -48px}
+.icon-picture{background-position:-456px -48px}
+.icon-pencil{background-position:0 -72px}
+.icon-map-marker{background-position:-24px -72px}
+.icon-adjust{background-position:-48px -72px}
+.icon-tint{background-position:-72px -72px}
+.icon-edit{background-position:-96px -72px}
+.icon-share{background-position:-120px -72px}
+.icon-check{background-position:-144px -72px}
+.icon-move{background-position:-168px -72px}
+.icon-step-backward{background-position:-192px -72px}
+.icon-fast-backward{background-position:-216px -72px}
+.icon-backward{background-position:-240px -72px}
+.icon-play{background-position:-264px -72px}
+.icon-pause{background-position:-288px -72px}
+.icon-stop{background-position:-312px -72px}
+.icon-forward{background-position:-336px -72px}
+.icon-fast-forward{background-position:-360px -72px}
+.icon-step-forward{background-position:-384px -72px}
+.icon-eject{background-position:-408px -72px}
+.icon-chevron-left{background-position:-432px -72px}
+.icon-chevron-right{background-position:-456px -72px}
+.icon-plus-sign{background-position:0 -96px}
+.icon-minus-sign{background-position:-24px -96px}
+.icon-remove-sign{background-position:-48px -96px}
+.icon-ok-sign{background-position:-72px -96px}
+.icon-question-sign{background-position:-96px -96px}
+.icon-info-sign{background-position:-120px -96px}
+.icon-screenshot{background-position:-144px -96px}
+.icon-remove-circle{background-position:-168px -96px}
+.icon-ok-circle{background-position:-192px -96px}
+.icon-ban-circle{background-position:-216px -96px}
+.icon-arrow-left{background-position:-240px -96px}
+.icon-arrow-right{background-position:-264px -96px}
+.icon-arrow-up{background-position:-289px -96px}
+.icon-arrow-down{background-position:-312px -96px}
+.icon-share-alt{background-position:-336px -96px}
+.icon-resize-full{background-position:-360px -96px}
+.icon-resize-small{background-position:-384px -96px}
+.icon-plus{background-position:-408px -96px}
+.icon-minus{background-position:-433px -96px}
+.icon-asterisk{background-position:-456px -96px}
+.icon-exclamation-sign{background-position:0 -120px}
+.icon-gift{background-position:-24px -120px}
+.icon-leaf{background-position:-48px -120px}
+.icon-fire{background-position:-72px -120px}
+.icon-eye-open{background-position:-96px -120px}
+.icon-eye-close{background-position:-120px -120px}
+.icon-warning-sign{background-position:-144px -120px}
+.icon-plane{background-position:-168px -120px}
+.icon-calendar{background-position:-192px -120px}
+.icon-random{background-position:-216px -120px;width:16px}
+.icon-comment{background-position:-240px -120px}
+.icon-magnet{background-position:-264px -120px}
+.icon-chevron-up{background-position:-288px -120px}
+.icon-chevron-down{background-position:-313px -119px}
+.icon-retweet{background-position:-336px -120px}
+.icon-shopping-cart{background-position:-360px -120px}
+.icon-folder-close{background-position:-384px -120px}
+.icon-folder-open{background-position:-408px -120px;width:16px}
+.icon-resize-vertical{background-position:-432px -119px}
+.icon-resize-horizontal{background-position:-456px -118px}
+.icon-hdd{background-position:0 -144px}
+.icon-bullhorn{background-position:-24px -144px}
+.icon-bell{background-position:-48px -144px}
+.icon-certificate{background-position:-72px -144px}
+.icon-thumbs-up{background-position:-96px -144px}
+.icon-thumbs-down{background-position:-120px -144px}
+.icon-hand-right{background-position:-144px -144px}
+.icon-hand-left{background-position:-168px -144px}
+.icon-hand-up{background-position:-192px -144px}
+.icon-hand-down{background-position:-216px -144px}
+.icon-circle-arrow-right{background-position:-240px -144px}
+.icon-circle-arrow-left{background-position:-264px -144px}
+.icon-circle-arrow-up{background-position:-288px -144px}
+.icon-circle-arrow-down{background-position:-312px -144px}
+.icon-globe{background-position:-336px -144px}
+.icon-wrench{background-position:-360px -144px}
+.icon-tasks{background-position:-384px -144px}
+.icon-filter{background-position:-408px -144px}
+.icon-briefcase{background-position:-432px -144px}
+.icon-fullscreen{background-position:-456px -144px}
+.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}
+.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}
+.well-large{padding:24px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}
+.well-small{padding:9px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}
+.btn{display:inline-block;*display:inline;*zoom:1;padding:4px 14px;margin-bottom:0;font-size:13px;line-height:20px;*line-height:20px;text-align:center;vertical-align:middle;cursor:pointer;color:#333;text-shadow:0 1px 1px rgba(255,255,255,0.75);background-color:#f5f5f5;background-image:-moz-linear-gradient(top,#fff,#e6e6e6);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#e6e6e6));background-image:-webkit-linear-gradient(top,#fff,#e6e6e6);background-image:-o-linear-gradient(top,#fff,#e6e6e6);background-image:linear-gradient(to bottom,#fff,#e6e6e6);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff',endColorstr='#ffe6e6e6',GradientType=0);border-color:#e6e6e6 #e6e6e6 #bfbfbf;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#e6e6e6;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);border:1px solid #bbb;*border:0;border-bottom-color:#a2a2a2;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;*margin-left:.3em;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05)}
+.btn:hover,.btn:active,.btn.active,.btn.disabled,.btn[disabled]{color:#333;background-color:#e6e6e6;*background-color:#d9d9d9}
+.btn:active,.btn.active{background-color:#ccc \9}
+.btn:first-child{*margin-left:0}
+.btn:hover{color:#333;text-decoration:none;background-color:#e6e6e6;*background-color:#d9d9d9;background-position:0 -15px;-webkit-transition:background-position .1s linear;-moz-transition:background-position .1s linear;-o-transition:background-position .1s linear;transition:background-position .1s linear}
+.btn:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
+.btn.active,.btn:active{background-color:#e6e6e6;background-color:#d9d9d9 \9;background-image:none;outline:0;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05)}
+.btn.disabled,.btn[disabled]{cursor:default;background-color:#e6e6e6;background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}
+.btn-large{padding:9px 14px;font-size:15px;line-height:normal;-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px}
+.btn-large [class^="icon-"]{margin-top:2px}
+.btn-small{padding:3px 9px;font-size:11px;line-height:18px}
+.btn-small [class^="icon-"]{margin-top:0}
+.btn-mini{padding:2px 6px;font-size:10px;line-height:17px}
+.btn-block{display:block;width:100%;padding-left:0;padding-right:0;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+.btn-block+.btn-block{margin-top:5px}
+input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}
+.btn-primary.active,.btn-warning.active,.btn-danger.active,.btn-success.active,.btn-info.active,.btn-inverse.active{color:rgba(255,255,255,0.75)}
+.btn{border-color:#c5c5c5;border-color:rgba(0,0,0,0.15) rgba(0,0,0,0.15) rgba(0,0,0,0.25)}
+.btn-primary{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#0054ab;background-image:-moz-linear-gradient(top,#0063ca,#003e7e);background-image:-webkit-gradient(linear,0 0,0 100%,from(#0063ca),to(#003e7e));background-image:-webkit-linear-gradient(top,#0063ca,#003e7e);background-image:-o-linear-gradient(top,#0063ca,#003e7e);background-image:linear-gradient(to bottom,#0063ca,#003e7e);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0063ca',endColorstr='#ff003e7e',GradientType=0);border-color:#003e7e #003e7e #001831;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#003e7e;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-primary:hover,.btn-primary:active,.btn-primary.active,.btn-primary.disabled,.btn-primary[disabled]{color:#fff;background-color:#003e7e;*background-color:#003164}
+.btn-primary:active,.btn-primary.active{background-color:#00254a \9}
+.btn-warning{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#faa732;background-image:-moz-linear-gradient(top,#fbb450,#f89406);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fbb450),to(#f89406));background-image:-webkit-linear-gradient(top,#fbb450,#f89406);background-image:-o-linear-gradient(top,#fbb450,#f89406);background-image:linear-gradient(to bottom,#fbb450,#f89406);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450',endColorstr='#fff89406',GradientType=0);border-color:#f89406 #f89406 #ad6704;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#f89406;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-warning:hover,.btn-warning:active,.btn-warning.active,.btn-warning.disabled,.btn-warning[disabled]{color:#fff;background-color:#f89406;*background-color:#df8505}
+.btn-warning:active,.btn-warning.active{background-color:#c67605 \9}
+.btn-danger{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#da4f49;background-image:-moz-linear-gradient(top,#ee5f5b,#bd362f);background-image:-webkit-gradient(linear,0 0,0 100%,from(#ee5f5b),to(#bd362f));background-image:-webkit-linear-gradient(top,#ee5f5b,#bd362f);background-image:-o-linear-gradient(top,#ee5f5b,#bd362f);background-image:linear-gradient(to bottom,#ee5f5b,#bd362f);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b',endColorstr='#ffbd362f',GradientType=0);border-color:#bd362f #bd362f #802420;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#bd362f;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-danger:hover,.btn-danger:active,.btn-danger.active,.btn-danger.disabled,.btn-danger[disabled]{color:#fff;background-color:#bd362f;*background-color:#a9302a}
+.btn-danger:active,.btn-danger.active{background-color:#942a25 \9}
+.btn-success{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#5bb75b;background-image:-moz-linear-gradient(top,#62c462,#51a351);background-image:-webkit-gradient(linear,0 0,0 100%,from(#62c462),to(#51a351));background-image:-webkit-linear-gradient(top,#62c462,#51a351);background-image:-o-linear-gradient(top,#62c462,#51a351);background-image:linear-gradient(to bottom,#62c462,#51a351);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462',endColorstr='#ff51a351',GradientType=0);border-color:#51a351 #51a351 #387038;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#51a351;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-success:hover,.btn-success:active,.btn-success.active,.btn-success.disabled,.btn-success[disabled]{color:#fff;background-color:#51a351;*background-color:#499249}
+.btn-success:active,.btn-success.active{background-color:#408140 \9}
+.btn-info{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#49afcd;background-image:-moz-linear-gradient(top,#5bc0de,#2f96b4);background-image:-webkit-gradient(linear,0 0,0 100%,from(#5bc0de),to(#2f96b4));background-image:-webkit-linear-gradient(top,#5bc0de,#2f96b4);background-image:-o-linear-gradient(top,#5bc0de,#2f96b4);background-image:linear-gradient(to bottom,#5bc0de,#2f96b4);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5bc0de',endColorstr='#ff2f96b4',GradientType=0);border-color:#2f96b4 #2f96b4 #1f6377;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#2f96b4;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-info:hover,.btn-info:active,.btn-info.active,.btn-info.disabled,.btn-info[disabled]{color:#fff;background-color:#2f96b4;*background-color:#2a85a0}
+.btn-info:active,.btn-info.active{background-color:#24748c \9}
+.btn-inverse{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#363636;background-image:-moz-linear-gradient(top,#444,#222);background-image:-webkit-gradient(linear,0 0,0 100%,from(#444),to(#222));background-image:-webkit-linear-gradient(top,#444,#222);background-image:-o-linear-gradient(top,#444,#222);background-image:linear-gradient(to bottom,#444,#222);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff444444',endColorstr='#ff222222',GradientType=0);border-color:#222 #222222 #000;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#222;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.btn-inverse:hover,.btn-inverse:active,.btn-inverse.active,.btn-inverse.disabled,.btn-inverse[disabled]{color:#fff;background-color:#222;*background-color:#151515}
+.btn-inverse:active,.btn-inverse.active{background-color:#080808 \9}
+button.btn,input[type="submit"].btn{*padding-top:3px;*padding-bottom:3px}
+button.btn::-moz-focus-inner,input[type="submit"].btn::-moz-focus-inner{padding:0;border:0}
+button.btn.btn-large,input[type="submit"].btn.btn-large{*padding-top:7px;*padding-bottom:7px}
+button.btn.btn-small,input[type="submit"].btn.btn-small{*padding-top:3px;*padding-bottom:3px}
+button.btn.btn-mini,input[type="submit"].btn.btn-mini{*padding-top:1px;*padding-bottom:1px}
+.btn-link,.btn-link:active,.btn-link[disabled]{background-color:transparent;background-image:none;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}
+.btn-link{border-color:transparent;cursor:pointer;color:#0063ca;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.btn-link:hover{color:#003e7e;text-decoration:underline;background-color:transparent}
+.btn-link[disabled]:hover{color:#333;text-decoration:none}
+.btn-group{position:relative;font-size:0;vertical-align:middle;white-space:nowrap;*margin-left:.3em}
+.btn-group:first-child{*margin-left:0}
+.btn-group+.btn-group{margin-left:5px}
+.btn-toolbar{font-size:0;margin-top:10px;margin-bottom:10px}
+.btn-toolbar .btn-group{display:inline-block;*display:inline;*zoom:1}
+.btn-toolbar .btn+.btn,.btn-toolbar .btn-group+.btn,.btn-toolbar .btn+.btn-group{margin-left:5px}
+.btn-group>.btn{position:relative;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.btn-group>.btn+.btn{margin-left:-1px}
+.btn-group>.btn,.btn-group>.dropdown-menu{font-size:13px}
+.btn-group>.btn-mini{font-size:11px}
+.btn-group>.btn-small{font-size:12px}
+.btn-group>.btn-large{font-size:16px}
+.btn-group>.btn:first-child{margin-left:0;-webkit-border-top-left-radius:4px;-moz-border-radius-topleft:4px;border-top-left-radius:4px;-webkit-border-bottom-left-radius:4px;-moz-border-radius-bottomleft:4px;border-bottom-left-radius:4px}
+.btn-group>.btn:last-child,.btn-group>.dropdown-toggle{-webkit-border-top-right-radius:4px;-moz-border-radius-topright:4px;border-top-right-radius:4px;-webkit-border-bottom-right-radius:4px;-moz-border-radius-bottomright:4px;border-bottom-right-radius:4px}
+.btn-group>.btn.large:first-child{margin-left:0;-webkit-border-top-left-radius:6px;-moz-border-radius-topleft:6px;border-top-left-radius:6px;-webkit-border-bottom-left-radius:6px;-moz-border-radius-bottomleft:6px;border-bottom-left-radius:6px}
+.btn-group>.btn.large:last-child,.btn-group>.large.dropdown-toggle{-webkit-border-top-right-radius:6px;-moz-border-radius-topright:6px;border-top-right-radius:6px;-webkit-border-bottom-right-radius:6px;-moz-border-radius-bottomright:6px;border-bottom-right-radius:6px}
+.btn-group>.btn:hover,.btn-group>.btn:focus,.btn-group>.btn:active,.btn-group>.btn.active{z-index:2}
+.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}
+.btn-group>.btn+.dropdown-toggle{padding-left:8px;padding-right:8px;-webkit-box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);*padding-top:5px;*padding-bottom:5px}
+.btn-group>.btn-mini+.dropdown-toggle{padding-left:5px;padding-right:5px;*padding-top:2px;*padding-bottom:2px}
+.btn-group>.btn-small+.dropdown-toggle{*padding-top:5px;*padding-bottom:4px}
+.btn-group>.btn-large+.dropdown-toggle{padding-left:12px;padding-right:12px;*padding-top:7px;*padding-bottom:7px}
+.btn-group.open .dropdown-toggle{background-image:none;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05)}
+.btn-group.open .btn.dropdown-toggle{background-color:#e6e6e6}
+.btn-group.open .btn-primary.dropdown-toggle{background-color:#003e7e}
+.btn-group.open .btn-warning.dropdown-toggle{background-color:#f89406}
+.btn-group.open .btn-danger.dropdown-toggle{background-color:#bd362f}
+.btn-group.open .btn-success.dropdown-toggle{background-color:#51a351}
+.btn-group.open .btn-info.dropdown-toggle{background-color:#2f96b4}
+.btn-group.open .btn-inverse.dropdown-toggle{background-color:#222}
+.btn .caret{margin-top:8px;margin-left:0}
+.btn-mini .caret,.btn-small .caret,.btn-large .caret{margin-top:6px}
+.btn-large .caret{border-left-width:5px;border-right-width:5px;border-top-width:5px}
+.dropup .btn-large .caret{border-bottom:5px solid #000;border-top:0}
+.btn-primary .caret,.btn-warning .caret,.btn-danger .caret,.btn-info .caret,.btn-success .caret,.btn-inverse .caret{border-top-color:#fff;border-bottom-color:#fff}
+.btn-group-vertical{display:inline-block;*display:inline;*zoom:1}
+.btn-group-vertical .btn{display:block;float:none;width:100%;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.btn-group-vertical .btn+.btn{margin-left:0;margin-top:-1px}
+.btn-group-vertical .btn:first-child{-webkit-border-radius:4px 4px 0 0;-moz-border-radius:4px 4px 0 0;border-radius:4px 4px 0 0}
+.btn-group-vertical .btn:last-child{-webkit-border-radius:0 0 4px 4px;-moz-border-radius:0 0 4px 4px;border-radius:0 0 4px 4px}
+.btn-group-vertical .btn-large:first-child{-webkit-border-radius:6px 6px 0 0;-moz-border-radius:6px 6px 0 0;border-radius:6px 6px 0 0}
+.btn-group-vertical .btn-large:last-child{-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px}
+.alert{padding:8px 35px 8px 14px;margin-bottom:20px;text-shadow:0 1px 0 rgba(255,255,255,0.5);background-color:#fcf8e3;border:1px solid #fbeed5;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;color:#c09853}
+.alert h4{margin:0}
+.alert .close{position:relative;top:-2px;right:-21px;line-height:20px}
+.alert-success{background-color:#dff0d8;border-color:#d6e9c6;color:#468847}
+.alert-danger,.alert-error{background-color:#f2dede;border-color:#eed3d7;color:#b94a48}
+.alert-info{background-color:#d9edf7;border-color:#bce8f1;color:#3a87ad}
+.alert-block{padding-top:14px;padding-bottom:14px}
+.alert-block>p,.alert-block>ul{margin-bottom:0}
+.alert-block p+p{margin-top:5px}
+.nav{margin-left:0;margin-bottom:20px;list-style:none}
+.nav>li>a{display:block}
+.nav>li>a:hover{text-decoration:none;background-color:#eee}
+.nav>.pull-right{float:right}
+.nav-header{display:block;padding:3px 15px;font-size:11px;font-weight:bold;line-height:20px;color:#999;text-shadow:0 1px 0 rgba(255,255,255,0.5);text-transform:uppercase}
+.nav li+.nav-header{margin-top:9px}
+.nav-list{padding-left:15px;padding-right:15px;margin-bottom:0}
+.nav-list>li>a,.nav-list .nav-header{margin-left:-15px;margin-right:-15px;text-shadow:0 1px 0 rgba(255,255,255,0.5)}
+.nav-list>li>a{padding:3px 15px}
+.nav-list>.active>a,.nav-list>.active>a:hover{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.2);background-color:#0063ca}
+.nav-list [class^="icon-"]{margin-right:2px}
+.nav-list .divider{*width:100%;height:1px;margin:9px 1px;*margin:-5px 0 5px;overflow:hidden;background-color:#e5e5e5;border-bottom:1px solid #fff}
+.nav>.disabled>a{color:#999}
+.nav>.disabled>a:hover{text-decoration:none;background-color:transparent;cursor:default}
+.navbar{overflow:visible;margin-bottom:20px;color:#777;*position:relative;*z-index:2}
+.navbar-inner{min-height:40px;padding-left:20px;padding-right:20px;background-color:#fafafa;background-image:-moz-linear-gradient(top,#fff,#f2f2f2);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#f2f2f2));background-image:-webkit-linear-gradient(top,#fff,#f2f2f2);background-image:-o-linear-gradient(top,#fff,#f2f2f2);background-image:linear-gradient(to bottom,#fff,#f2f2f2);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff',endColorstr='#fff2f2f2',GradientType=0);border:1px solid #d4d4d4;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 1px 4px rgba(0,0,0,0.065);-moz-box-shadow:0 1px 4px rgba(0,0,0,0.065);box-shadow:0 1px 4px rgba(0,0,0,0.065);*zoom:1}
+.navbar-inner:before,.navbar-inner:after{display:table;content:"";line-height:0}
+.navbar-inner:after{clear:both}
+.navbar .container{width:auto}
+.nav-collapse.collapse{height:auto}
+.navbar .brand{float:left;display:block;padding:4px 20px 0;margin-left:-20px;font-size:20px;font-weight:200;color:#777;text-shadow:0 1px 0 #fff}
+.navbar .brand:hover{text-decoration:none}
+.navbar-text{margin-bottom:0;line-height:40px}
+.navbar-link{color:#777}
+.navbar-link:hover{color:#333}
+.navbar .divider-vertical{height:40px;margin:0 9px;border-left:1px solid #f2f2f2;border-right:1px solid #fff}
+.navbar .btn,.navbar .btn-group{margin-top:5px}
+.navbar .btn-group .btn,.navbar .input-prepend .btn,.navbar .input-append .btn{margin-top:0}
+.navbar-form{margin-bottom:0;*zoom:1}
+.navbar-form:before,.navbar-form:after{display:table;content:"";line-height:0}
+.navbar-form:after{clear:both}
+.navbar-form input,.navbar-form select,.navbar-form .radio,.navbar-form .checkbox{margin-top:5px}
+.navbar-form input,.navbar-form select,.navbar-form .btn{display:inline-block;margin-bottom:0}
+.navbar-form input[type="image"],.navbar-form input[type="checkbox"],.navbar-form input[type="radio"]{margin-top:3px}
+.navbar-form .input-append,.navbar-form .input-prepend{margin-top:6px;white-space:nowrap}
+.navbar-form .input-append input,.navbar-form .input-prepend input{margin-top:0}
+.navbar-search{position:relative;float:left;margin-top:5px;margin-bottom:0}
+.navbar-search .search-query{margin-bottom:0;padding:4px 14px;font-family:"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:1;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px}
+.navbar-static-top{position:static;width:100%;margin-bottom:0}
+.navbar-static-top .navbar-inner{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;z-index:10300;margin-bottom:0}
+.navbar-fixed-top .navbar-inner,.navbar-static-top .navbar-inner{border-width:0 0 1px}
+.navbar-fixed-bottom .navbar-inner{border-width:1px 0 0}
+.navbar-fixed-top .navbar-inner,.navbar-fixed-bottom .navbar-inner{padding-left:0;padding-right:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.navbar-static-top .container,.navbar-fixed-top .container,.navbar-fixed-bottom .container{width:940px}
+.navbar-fixed-top{top:0}
+.navbar-fixed-top .navbar-inner,.navbar-static-top .navbar-inner{-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.1),0 1px 10px rgba(0,0,0,0.1);-moz-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.1),0 1px 10px rgba(0,0,0,0.1);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.1),0 1px 10px rgba(0,0,0,0.1)}
+.navbar-fixed-bottom{bottom:0}
+.navbar-fixed-bottom .navbar-inner{-webkit-box-shadow:inset 0 1px 0 rgba(0,0,0,0.1),0 -1px 10px rgba(0,0,0,0.1);-moz-box-shadow:inset 0 1px 0 rgba(0,0,0,0.1),0 -1px 10px rgba(0,0,0,0.1);box-shadow:inset 0 1px 0 rgba(0,0,0,0.1),0 -1px 10px rgba(0,0,0,0.1)}
+.navbar .nav{position:relative;left:0;display:block;float:left;margin:0 10px 0 0}
+.navbar .nav.pull-right{float:right;margin-right:0}
+.navbar .nav>li{float:left}
+.navbar .nav>li>a{float:none;padding:10px 15px 10px;color:#777;text-decoration:none;text-shadow:0 1px 0 #fff}
+.navbar .nav .dropdown-toggle .caret{margin-top:8px}
+.navbar .nav>li>a:focus,.navbar .nav>li>a:hover{background-color:transparent;color:#333;text-decoration:none}
+.navbar .nav>.active>a,.navbar .nav>.active>a:hover,.navbar .nav>.active>a:focus{color:#555;text-decoration:none;background-color:#e5e5e5;-webkit-box-shadow:inset 0 3px 8px rgba(0,0,0,0.125);-moz-box-shadow:inset 0 3px 8px rgba(0,0,0,0.125);box-shadow:inset 0 3px 8px rgba(0,0,0,0.125)}
+.navbar .btn-navbar{display:none;float:right;padding:7px 10px;margin-left:5px;margin-right:5px;color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#ededed;background-image:-moz-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f2f2f2),to(#e5e5e5));background-image:-webkit-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:-o-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:linear-gradient(to bottom,#f2f2f2,#e5e5e5);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2',endColorstr='#ffe5e5e5',GradientType=0);border-color:#e5e5e5 #e5e5e5 #bfbfbf;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#e5e5e5;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075)}
+.navbar .btn-navbar:hover,.navbar .btn-navbar:active,.navbar .btn-navbar.active,.navbar .btn-navbar.disabled,.navbar .btn-navbar[disabled]{color:#fff;background-color:#e5e5e5;*background-color:#d9d9d9}
+.navbar .btn-navbar:active,.navbar .btn-navbar.active{background-color:#ccc \9}
+.navbar .btn-navbar .icon-bar{display:block;width:18px;height:2px;background-color:#f5f5f5;-webkit-border-radius:1px;-moz-border-radius:1px;border-radius:1px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.25);-moz-box-shadow:0 1px 0 rgba(0,0,0,0.25);box-shadow:0 1px 0 rgba(0,0,0,0.25)}
+.btn-navbar .icon-bar+.icon-bar{margin-top:3px}
+.navbar .nav>li>.dropdown-menu:before{content:'';display:inline-block;border-left:7px solid transparent;border-right:7px solid transparent;border-bottom:7px solid #ccc;border-bottom-color:rgba(0,0,0,0.2);position:absolute;top:-7px;left:9px}
+.navbar .nav>li>.dropdown-menu:after{content:'';display:inline-block;border-left:6px solid transparent;border-right:6px solid transparent;border-bottom:6px solid #fff;position:absolute;top:-6px;left:10px}
+.navbar-fixed-bottom .nav>li>.dropdown-menu:before{border-top:7px solid #ccc;border-top-color:rgba(0,0,0,0.2);border-bottom:0;bottom:-7px;top:auto}
+.navbar-fixed-bottom .nav>li>.dropdown-menu:after{border-top:6px solid #fff;border-bottom:0;bottom:-6px;top:auto}
+.navbar .nav li.dropdown.open>.dropdown-toggle,.navbar .nav li.dropdown.active>.dropdown-toggle,.navbar .nav li.dropdown.open.active>.dropdown-toggle{background-color:#e5e5e5;color:#555}
+.navbar .nav li.dropdown>.dropdown-toggle .caret{border-top-color:#777;border-bottom-color:#777}
+.navbar .nav li.dropdown.open>.dropdown-toggle .caret,.navbar .nav li.dropdown.active>.dropdown-toggle .caret,.navbar .nav li.dropdown.open.active>.dropdown-toggle .caret{border-top-color:#555;border-bottom-color:#555}
+.navbar .pull-right>li>.dropdown-menu,.navbar .nav>li>.dropdown-menu.pull-right{left:auto;right:0}
+.navbar .pull-right>li>.dropdown-menu:before,.navbar .nav>li>.dropdown-menu.pull-right:before{left:auto;right:12px}
+.navbar .pull-right>li>.dropdown-menu:after,.navbar .nav>li>.dropdown-menu.pull-right:after{left:auto;right:13px}
+.navbar .pull-right>li>.dropdown-menu .dropdown-menu,.navbar .nav>li>.dropdown-menu.pull-right .dropdown-menu{left:auto;right:100%;margin-left:0;margin-right:-1px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px}
+.navbar-inverse{color:#fff}
+.navbar-inverse .navbar-inner{background-color:#0052a8;background-image:-moz-linear-gradient(top,#0063ca,#003874);background-image:-webkit-gradient(linear,0 0,0 100%,from(#0063ca),to(#003874));background-image:-webkit-linear-gradient(top,#0063ca,#003874);background-image:-o-linear-gradient(top,#0063ca,#003874);background-image:linear-gradient(to bottom,#0063ca,#003874);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0063ca',endColorstr='#ff003874',GradientType=0);border-color:#252525}
+.navbar-inverse .brand,.navbar-inverse .nav>li>a{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25)}
+.navbar-inverse .brand:hover,.navbar-inverse .nav>li>a:hover{color:#fff}
+.navbar-inverse .nav>li>a:focus,.navbar-inverse .nav>li>a:hover{background-color:transparent;color:#fff}
+.navbar-inverse .nav .active>a,.navbar-inverse .nav .active>a:hover,.navbar-inverse .nav .active>a:focus{color:#fff;background-color:#003874}
+.navbar-inverse .navbar-link{color:#fff}
+.navbar-inverse .navbar-link:hover{color:#fff}
+.navbar-inverse .divider-vertical{border-left-color:#003874;border-right-color:#0063ca}
+.navbar-inverse .nav li.dropdown.open>.dropdown-toggle,.navbar-inverse .nav li.dropdown.active>.dropdown-toggle,.navbar-inverse .nav li.dropdown.open.active>.dropdown-toggle{background-color:#003874;color:#fff}
+.navbar-inverse .nav li.dropdown>.dropdown-toggle .caret{border-top-color:#fff;border-bottom-color:#fff}
+.navbar-inverse .nav li.dropdown.open>.dropdown-toggle .caret,.navbar-inverse .nav li.dropdown.active>.dropdown-toggle .caret,.navbar-inverse .nav li.dropdown.open.active>.dropdown-toggle .caret{border-top-color:#fff;border-bottom-color:#fff}
+.navbar-inverse .navbar-search .search-query{color:#fff;background-color:#0076f3;border-color:#003874;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);-moz-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);-webkit-transition:none;-moz-transition:none;-o-transition:none;transition:none}
+.navbar-inverse .navbar-search .search-query:-moz-placeholder{color:#ccc}
+.navbar-inverse .navbar-search .search-query:-ms-input-placeholder{color:#ccc}
+.navbar-inverse .navbar-search .search-query::-webkit-input-placeholder{color:#ccc}
+.navbar-inverse .navbar-search .search-query:focus,.navbar-inverse .navbar-search .search-query.focused{padding:5px 15px;color:#333;text-shadow:0 1px 0 #fff;background-color:#fff;border:0;-webkit-box-shadow:0 0 3px rgba(0,0,0,0.15);-moz-box-shadow:0 0 3px rgba(0,0,0,0.15);box-shadow:0 0 3px rgba(0,0,0,0.15);outline:0}
+.navbar-inverse .btn-navbar{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#00458e;background-image:-moz-linear-gradient(top,#0057b1,#002c5a);background-image:-webkit-gradient(linear,0 0,0 100%,from(#0057b1),to(#002c5a));background-image:-webkit-linear-gradient(top,#0057b1,#002c5a);background-image:-o-linear-gradient(top,#0057b1,#002c5a);background-image:linear-gradient(to bottom,#0057b1,#002c5a);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0057b1',endColorstr='#ff002c5a',GradientType=0);border-color:#002c5a #002c5a #00070e;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);*background-color:#002c5a;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false)}
+.navbar-inverse .btn-navbar:hover,.navbar-inverse .btn-navbar:active,.navbar-inverse .btn-navbar.active,.navbar-inverse .btn-navbar.disabled,.navbar-inverse .btn-navbar[disabled]{color:#fff;background-color:#002c5a;*background-color:#001f41}
+.navbar-inverse .btn-navbar:active,.navbar-inverse .btn-navbar.active{background-color:#001327 \9}
+.breadcrumb{padding:8px 15px;margin:0 0 20px;list-style:none;background-color:#f5f5f5;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}
+.breadcrumb li{display:inline-block;*display:inline;*zoom:1;text-shadow:0 1px 0 #fff}
+.breadcrumb .divider{padding:0 5px;color:#ccc}
+.breadcrumb .active{color:#999}
+.thumbnails{margin-left:-20px;list-style:none;*zoom:1}
+.thumbnails:before,.thumbnails:after{display:table;content:"";line-height:0}
+.thumbnails:after{clear:both}
+.row-fluid .thumbnails{margin-left:0}
+.thumbnails>li{float:left;margin-bottom:20px;margin-left:20px}
+.thumbnail{display:block;padding:4px;line-height:20px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.055);-moz-box-shadow:0 1px 3px rgba(0,0,0,0.055);box-shadow:0 1px 3px rgba(0,0,0,0.055);-webkit-transition:all .2s ease-in-out;-moz-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out}
+a.thumbnail:hover{border-color:#0063ca;-webkit-box-shadow:0 1px 4px rgba(0,105,214,0.25);-moz-box-shadow:0 1px 4px rgba(0,105,214,0.25);box-shadow:0 1px 4px rgba(0,105,214,0.25)}
+.thumbnail>img{display:block;max-width:100%;margin-left:auto;margin-right:auto}
+.thumbnail .caption{padding:9px;color:#555}
+.label,.badge{font-size:10.998px;font-weight:bold;line-height:14px;color:#fff;vertical-align:baseline;white-space:nowrap;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#999}
+.label{padding:1px 4px 2px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}
+.badge{padding:1px 9px 2px;-webkit-border-radius:9px;-moz-border-radius:9px;border-radius:9px}
+a.label:hover,a.badge:hover{color:#fff;text-decoration:none;cursor:pointer}
+.label-important,.badge-important{background-color:#b94a48}
+.label-important[href],.badge-important[href]{background-color:#953b39}
+.label-warning,.badge-warning{background-color:#f89406}
+.label-warning[href],.badge-warning[href]{background-color:#c67605}
+.label-success,.badge-success{background-color:#468847}
+.label-success[href],.badge-success[href]{background-color:#356635}
+.label-info,.badge-info{background-color:#3a87ad}
+.label-info[href],.badge-info[href]{background-color:#2d6987}
+.label-inverse,.badge-inverse{background-color:#333}
+.label-inverse[href],.badge-inverse[href]{background-color:#1a1a1a}
+.btn .label,.btn .badge{position:relative;top:-1px}
+.btn-mini .label,.btn-mini .badge{top:0}
+.hero-unit{padding:50px;margin-bottom:30px;background-color:#eee;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}
+.hero-unit h1{margin-bottom:10px;margin-top:0;font-size:40px;line-height:1;color:inherit;letter-spacing:-1px;text-align:center}
+.hero-unit h2{font-size:30px;margin:0}
+.hero-unit p{font-size:16px;font-weight:200;line-height:25px;color:inherit}
+.pull-right{float:right}
+.pull-left{float:left}
+.hide{display:none}
+.show{display:block}
+.invisible{visibility:hidden}
+.affix{position:fixed}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
         user_omniauth_authorize_path(:provider => 'google_oauth2'),
         new_user_session_path, new_user_registration_path,
         new_user_password_path, edit_user_password_path,
-        destroy_user_session_path
+        destroy_user_session_path, user_confirmation_path
       ]
 
       return if request.xhr? or request.path.match(Regexp.union(ignore_paths))

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -3,6 +3,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     class_eval %Q{
       def #{provider}
         @user = User.find_for_oauth(env["omniauth.auth"], current_user)
+        @user.skip_confirmation!
 
         if @user.persisted?
           sign_in_and_redirect @user, event: :authentication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
   TEMP_EMAIL_REGEX = /\Achange@me/
 
   devise :database_authenticatable, :registerable, :recoverable,
-         :rememberable, :trackable, :validatable, :omniauthable
+         :rememberable, :trackable, :validatable, :omniauthable, :confirmable
 
   attr_accessible :email, :password, :password_confirmation, :remember_me, :role,
                   :name, :city, :country, :country, :bio

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,6 @@
-<p>Welcome <%= @email %>!</p>
+<h1>Welcome, <%= @email %>!</h1>
 
-<p>You can confirm your account email through the link below:</p>
+<p>You can confirm your account email by clicking this <%= link_to 'link', confirmation_url(@resource, confirmation_token: @token) %>.<br />
+If that doesn't work, follow the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to confirmation_url(@resource, confirmation_token: @token), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+     <%= KhanBurmese::Application.assets['bootstrap-email.min.css'].to_s.html_safe %>
+  </style>
+</head>
+
+<body>
+<div class="container">
+  <%= yield %>
+</div>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,10 @@ module KhanBurmese
 
     # Fix for Bootstrap fonts.
     config.assets.paths << "#{Rails}/vendor/assets/fonts"
+
+    # Devise and Roadie integration:
+    config.to_prepare do
+      Devise::Mailer.layout 'email'
+    end
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -9,3 +9,5 @@ production:
   facebook_private_key: 'INSERT_FACEBOOK_APP_SECRET'
   google_public_key: 'INSERT_GOOGLE_PUBLIC_KEY'
   google_private_key: 'INSERT_GOOGLE_PRIVATE_KEY'
+  sendgrid_username: 'INSERT_SENDGRID_USERNAME'
+  sendgrid_password: 'INSERT_SENDGRID_PASSWORD'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,9 @@ KhanBurmese::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  # Devise setup:
-  config.action_mailer.default_url_options = { host: 'localhost', post: 3000 }	
+  # ActionMailer setup:
+  config.action_mailer.default_url_options = { :host => 'localhost', :port => 3000 }
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => 'localhost', :port => 1025 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,4 +64,18 @@ KhanBurmese::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # ActionMailer setup:
+  config.action_mailer.default_url_options = { :host => 'khanburmese.heroku.com' }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address =>              'smtp.sendgrid.net',
+    :port =>                 '587',
+    :authentication =>       :plain,
+    :user_name =>            ENV['sendgrid_username'],
+    :password =>             ENV['sendgrid_password'],
+    :domain =>               'heroku.com',
+    :enable_starttls_auto => true
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,4 +34,12 @@ KhanBurmese::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Devise setup:
+  config.action_mailer.default_url_options = { :host => 'localhost', :port => 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => 'localhost', :port => 1025 }
+
+  # Set to false else Cucumber will Mailcatcher running:
+  config.action_mailer.perform_deliveries = false
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -119,7 +119,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [ :email ]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'khanburmese@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,7 +18,7 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Confirmation Instructions"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/db/migrate/20150316040925_add_confirmable_to_users.rb
+++ b/db/migrate/20150316040925_add_confirmable_to_users.rb
@@ -1,0 +1,7 @@
+class AddConfirmableToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150314053236) do
+ActiveRecord::Schema.define(:version => 20150316040925) do
 
   create_table "identities", :force => true do |t|
     t.integer  "user_id"
@@ -74,6 +74,9 @@ ActiveRecord::Schema.define(:version => 20150314053236) do
     t.string   "city"
     t.string   "country"
     t.text     "bio"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -12,7 +12,7 @@ Scenario: Sign up with valid email and password.
   And I fill in "user_password" with "password"
   And I fill in "user_password_confirmation" with "password"
   And I press "Sign Up"
-  Then I should see "Welcome! You have signed up successfully."
+  Then I should see "A message with a confirmation link has been sent to your email address."
 
 Scenario: Sign up with invalid password.
   When I fill in "user_email" with "test@test.com"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -5,7 +5,7 @@ end
 Given /^I log in by email$/ do
   email = 'testing@man.net'
   password = 'secretpass'
-  User.new(:email => email, :password => password, :password_confirmation => password).save!
+  User.create(:email => email, :password => password, :password_confirmation => password).confirm!
 
   visit '/users/sign_in'
   fill_in "user_email", :with => email

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -4,6 +4,6 @@ Given /^the following users:$/ do |users|
     password = user['password']
     role = user['role']
 
-    user = User.create(:email => email, :password => password, :password_confirmation => password, :role => role)
+    User.create(:email => email, :password => password, :password_confirmation => password, :role => role).confirm!
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -10,7 +10,7 @@ module ControllerMacros
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryGirl.create(:user)
-      # user.confirm!
+      user.confirm!
       sign_in user
     end
   end


### PR DESCRIPTION
Set up email confirmations with a Bootstrap email template. Even works on production (tested)!

To test in development, install the gem `mailcatcher` (not included in Gemfile). Run `mailcatcher -f -v` and open the link in a browser window. All emails will be intercepted.

TODO: Add tests for email verification. Currently, coverage is under 90%.

Reviewer: @nalnaji