### PR TITLE
Prioritization for videos.

### DIFF
--- a/app/assets/javascripts/videos.js
+++ b/app/assets/javascripts/videos.js
@@ -1,0 +1,13 @@
+$(function() {
+  $('#video-search input').keyup(function() {
+    $.get($('#video-search').attr('action'), $('#video-search').serialize(), null, 'script');
+    return false;
+  });
+  $('#video-search input').keyup();
+  $('#search').focus();
+});
+
+function starClick(element) {
+  wrapper = $(element.parentNode);
+  wrapper.html('<i class="fa fa-spinner fa-pulse fa-starry fa-lg fa-fw"></i>');
+}

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -2,6 +2,12 @@ body {
   padding-top: 70px;
 }
 
+/* Wrapper div. */
+
+.wrapper {
+  display: inline;
+}
+
 /* Color override for social buttons. */
 
 .btn-social {
@@ -85,4 +91,18 @@ body {
   margin-left: 10px;
   height: 50px;
   width: 50px;
+}
+
+/* Video stars. */
+
+.fa-starry {
+  margin-right: 10px;
+}
+
+.fa-star-starred {
+  color: #30a7fc;
+}
+
+.fa-star-unstarred {
+  color: #888;
 }

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -24,7 +24,7 @@ body {
   padding: 0px;
 }
 
-/* Logo */
+/* Logo. */
 
 .img-logo {
   height: 35px;
@@ -39,7 +39,7 @@ body {
   display: inline-block;
 }
 
-/* Modules (Dashboard)*/
+/* Dashboard modules. */
 
 .module {
   border-radius: 15px;
@@ -71,7 +71,7 @@ body {
   border-bottom-right-radius: 15px;
 }
 
-/* Ranking */
+/* Ranking. */
 
 .module > .media-body {
   width: 100%;

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -2,6 +2,16 @@ class VideosController < ApplicationController
   autocomplete :tag, :name, :class_name => 'ActsAsTaggableOn::Tag'
 
   def index
-    @videos = Video.search(params[:search])
+    @videos = Video.search(params[:search]).sort_by {
+      |video| video.starred ? 0 : 1
+    }
+  end
+
+  def toggle_star
+    @video = Video.find(params[:video_id])
+    authorize! :star, @video
+
+    @video.toggle :starred
+    @video.save
   end
 end

--- a/app/helpers/video_helper.rb
+++ b/app/helpers/video_helper.rb
@@ -6,7 +6,7 @@ module VideoHelper
     html = ''
     if can? :star, video
       i_class = ''
-      options = { :'data-method' => :put, :remote => true }
+      options = { :'data-method' => :put, :remote => true, :onclick => 'starClick(this);' }
 
       if video.starred
         i_class = i_starred

--- a/app/helpers/video_helper.rb
+++ b/app/helpers/video_helper.rb
@@ -1,0 +1,28 @@
+module VideoHelper
+  def toggle_star_button(video)
+    i_starred = '<i class="fa fa-lg fa-star fa-starry fa-star-starred fa-fw"></i>'.html_safe
+    i_unstarred = '<i class="fa fa-lg fa-star fa-starry fa-star-unstarred fa-fw"></i>'.html_safe
+
+    html = ''
+    if can? :star, video
+      i_class = ''
+      options = { :'data-method' => :put, :remote => true }
+
+      if video.starred
+        i_class = i_starred
+      else
+        i_class = i_unstarred
+      end
+
+      html += link_to video_toggle_star_path(video), options do
+        i_class
+      end
+    else
+      if video.starred
+        html += i_starred
+      end
+    end
+
+    html.html_safe
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,6 +17,9 @@ class Ability
     can :access, :rails_admin
     can :dashboard
 
+    # Videos:
+    can :star, :videos
+
     # Superior power. Use with discretion.
     can :manage, :all
   end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,5 @@
 class Video < ActiveRecord::Base
-  attr_accessible :description, :title, :youtube_id
+  attr_accessible :description, :title, :youtube_id, :starred
   acts_as_taggable
 
   def youtube_link

--- a/app/views/videos/_video_list.html.erb
+++ b/app/views/videos/_video_list.html.erb
@@ -5,12 +5,7 @@
   <table class="table">
     <tbody>
       <% @videos.each do |video| %>
-        <tr>
-          <td>
-            <%= link_to video.title, video %>
-          </td>
-          <td><%= video.youtube_link %><td>
-        </tr>
+        <%= render 'video_row', video: video %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/videos/_video_row.html.erb
+++ b/app/views/videos/_video_row.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td>
+    <div id="toggle-star-<%= video.id %>" class="wrapper">
+      <%= toggle_star_button(video) %>
+    </div>
+    <%= link_to video.title, video %>
+  </td>
+  <td><%= video.youtube_link %><td>
+</tr>

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -25,4 +25,9 @@ $(function() {
   $('#search').focus();
 });
 
+function starClick(element) {
+  wrapper = $(element.parentNode);
+  wrapper.html('<i class="fa fa-spinner fa-pulse fa-starry fa-lg fa-fw"></i>');
+}
+
 <% end %>

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -12,22 +12,3 @@
 
 <div id="video-list">
 </div>
-
-<!-- Javascript here: -->
-<%= javascript_tag do %>
-
-$(function() {
-  $('#video-search input').keyup(function() {
-    $.get($('#video-search').attr('action'), $('#video-search').serialize(), null, 'script');
-    return false;
-  });
-  $('#video-search input').keyup();
-  $('#search').focus();
-});
-
-function starClick(element) {
-  wrapper = $(element.parentNode);
-  wrapper.html('<i class="fa fa-spinner fa-pulse fa-starry fa-lg fa-fw"></i>');
-}
-
-<% end %>

--- a/app/views/videos/toggle_star.js.erb
+++ b/app/views/videos/toggle_star.js.erb
@@ -1,0 +1,3 @@
+$('#toggle-star-<%= @video.id %>').html("<%= escape_javascript(
+  toggle_star_button(@video)
+) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ KhanBurmese::Application.routes.draw do
   resources :videos do
     # Autocompletion for tags:
     get :autocomplete_tag_name, :on => :collection
+    # Star or unstar videos:
+    put :toggle_star
   end
 
   # The priority is based upon order of creation:

--- a/db/migrate/20150321032226_add_starred_to_videos.rb
+++ b/db/migrate/20150321032226_add_starred_to_videos.rb
@@ -1,0 +1,5 @@
+class AddStarredToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :starred, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150316040925) do
+ActiveRecord::Schema.define(:version => 20150321032226) do
 
   create_table "identities", :force => true do |t|
     t.integer  "user_id"
@@ -86,8 +86,9 @@ ActiveRecord::Schema.define(:version => 20150316040925) do
     t.string   "youtube_id"
     t.string   "title"
     t.text     "description"
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
+    t.boolean  "starred",     :default => false
   end
 
 end


### PR DESCRIPTION
Added "starred" prioritization for videos.

Only administrators can star videos. Videos can be starred one at a time; unstarred videos will have a gray star. When clicked, the icon will be replaced with a "loading" pulse until the AJAX call has completed, when the star will be toggled.
Normal volunteers will only see a blue star for prioritized videos. Unstarred videos will not have a gray star.

Severely untested. To reviewer, please test thoroughly, including both as administrator (who can star/unstar) and as users. AJAX sync is a bit weird, too, given that there are two AJAX actions on this page.

Reviewer: @nalnaji