### PR TITLE
Translations Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ coverage/*
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore all stored files
+/public/srt/*

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,0 +1,12 @@
+class TranslationsController < ApplicationController
+  def upload
+    @video = Video.find(params[:video_id])
+    @translation = Translation.find(params[:translation_id])
+    begin
+      @translation.upload_srt(params[:srt])
+    rescue Exception => exception
+      add_flash(:alert, exception.message)
+    end
+    redirect_to video_path @video
+  end
+end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,7 +1,36 @@
 class Translation < ActiveRecord::Base
-	belongs_to :user
-	belongs_to :video
-	attr_accessible :user, :video
+  belongs_to :user
+  belongs_to :video
+  attr_accessible :user, :video
 
-	validates_presence_of :video
+  validates_presence_of :video
+
+  def upload_srt(srt)
+    Translation.verify_file(srt)
+
+    root_folder_name = 'public/srt/'
+    Translation.make_folder(root_folder_name)
+
+    folder_name = "#{root_folder_name}#{self.id}/"
+    Translation.make_folder(folder_name)
+
+    file_name =  "#{self.id}.srt"
+    path = File.join(folder_name, file_name)
+    File.open(path, 'w+') { |f| f.write(srt.read) }
+  end
+
+  private
+  def self.make_folder(folder_name)
+    unless File.exist?(folder_name)
+      Dir::mkdir(folder_name)
+    end
+  end
+
+  def self.verify_file(srt)
+    if srt.nil?
+      raise Exception.new('Missing file.')
+    elsif File.extname(srt.original_filename) != '.srt' 
+      raise Exception.new('Invalid file type.')
+    end
+  end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -6,7 +6,7 @@ class Video < ActiveRecord::Base
   has_many :translators, :through => :translations, :source => :user
 
   def youtube_link
-    "https://www.youtube.com/watch?v=#{self.youtube_id}"
+    "http://www.youtube.com/embed/#{self.youtube_id}"
   end
 
   def self.search(search)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ KhanBurmese::Application.routes.draw do
     get :autocomplete_tag_name, :on => :collection
     # Star or unstar videos:
     put :toggle_star
+    resources :translations do
+      post 'upload' => 'translations#upload'
+    end
   end
 
   # The priority is based upon order of creation:


### PR DESCRIPTION
Back end in place for uploading SRTs, storing them in public/srts, and managing any duplicate uploads both in the database and file system. The views for vides/show.html.erb and translations/show.html.erb haven't been added.

In views/videos/show.html.erb, the form for uploading a file should look like:
```ruby
<%= form_tag(video_translations_path(@video), {:multipart => true}) do %>
  <%= file_field_tag 'srt' %>
  <%= hidden_field_tag 'video_id', @video.id %>
  <%= submit_tag 'Upload' %>
<% end %>
```
reviewer @jonathanshum, @DarryQueen 