### PR TITLE
Added controller section for prototypes.

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -94,6 +94,12 @@ html{
   }
 }
 
+/* Links on preview page. */
+
+.preview-links {
+  margin-top: 30px;
+}
+
 /* Dashboard modules. */
 
 .module {

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,0 +1,14 @@
+class PreviewController < ApplicationController
+  def show
+    authorize! :read, :prototype
+
+    if params[:page]
+      render params[:page]
+    else
+      @pages = Dir.glob("#{Rails.root}/app/views/preview/[^index]*.html.erb").map {
+        |path| File.basename(path, '.html.erb')
+      }
+      render 'index'
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,9 @@ class Ability
   def admin
     volunteer
 
+    # Previews:
+    can :read, :prototype
+
     # Videos:
     can :star, Video
 

--- a/app/views/preview/index.html.erb
+++ b/app/views/preview/index.html.erb
@@ -1,0 +1,10 @@
+<h1>Previews</h1>
+<p>
+  Here you can find the list of prototypes. Note that none of these pages will work as intended; they are mockups for look-and-feel.
+
+  <div class="preview-links">
+    <% @pages.each do |page| %>
+      <b><%= link_to page.titleize, params.merge({ :page => page }) %></b>
+    <% end %>
+  </div>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ KhanBurmese::Application.routes.draw do
   root :to => 'home#index'
   get 'home' => 'home#dashboard', :as => :dashboard
 
+  # For page prototypes:
+  get 'preview' => 'preview#show', :as => :prototype
+
   resources :videos do
     # Autocompletion for tags:
     get :autocomplete_tag_name, :on => :collection


### PR DESCRIPTION
For prototype pages. Put all prototypes in `app/views/preview`. No longer any need to create separate routes for these pages. Simply create a `.html.erb` page, and it will show up under the listing at `/preview`.

Reviewer: @jonathanshum