### PR TITLE
Point system migration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,10 @@ class User < ActiveRecord::Base
     self.translation_videos.select { |video| video.translated? }
   end
 
+  def points
+    self.translations.reduce(0) { |sum, translation| sum + translation.points }
+  end
+
   def is?(role)
     role.to_s == self.role
   end

--- a/db/migrate/20150409011626_add_status_to_translation.rb
+++ b/db/migrate/20150409011626_add_status_to_translation.rb
@@ -1,0 +1,6 @@
+class AddStatusToTranslation < ActiveRecord::Migration
+  def change
+    add_column :translations, :status, :int, :default => 0
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150408010213) do
+ActiveRecord::Schema.define(:version => 20150409011626) do
 
   create_table "identities", :force => true do |t|
     t.integer  "user_id"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(:version => 20150408010213) do
     t.datetime "time_last_updated"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "status",            :default => 0
   end
 
   create_table "users", :force => true do |t|


### PR DESCRIPTION
Translations now store a status (incomplete, complete, complete with priority), can share their point value, and users can tell their point value. Upon uploading without an exception, translation statuses are updated depending on video starred status at the time of upload. If a translation was ever uploaded when the associated video had priority (and didn't cause an exception), then it will still have the priority-number of points (so we don't discourage people from editing their translations).

reviewer: @DarryQueen 