### PR TITLE
Amara integration.

### DIFF
--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -36,6 +36,20 @@ class TranslationsController < ApplicationController
     redirect_to video_path @video
   end
 
+  def submit_amara
+    @video = Video.find(params[:video_id])
+    @translation = Translation.find(params[:translation_id])
+
+    authorize! :upload, @translation
+
+    begin
+      @translation.upload_amara(params[:amara_link])
+    rescue ArgumentError => e
+      add_flash(:alert, e.message)
+    end
+    redirect_to video_path @video
+  end
+
   def vote
     @video = Video.find(params[:video_id])
     @translation = Translation.find(params[:translation_id])

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -70,6 +70,20 @@ class Translation < ActiveRecord::Base
     complete
   end
 
+  def upload_amara(amara_link)
+    amara_link = amara_link.gsub('https', 'http')
+    Translation.verify_link(amara_link)
+
+    srt_link = Video.get_srt_link_from_amara(amara_link)
+    raise ArgumentError, 'No SRT published.' unless srt_link
+
+    self.srt = URI.parse(srt_link)
+    self.save
+
+    update_time
+    complete
+  end
+
   private
   def update_time
     self.time_last_updated = Time.now
@@ -81,6 +95,12 @@ class Translation < ActiveRecord::Base
       raise ArgumentError, 'Missing file.'
     elsif File.extname(srt.original_filename) != '.srt' 
       raise ArgumentError, 'Invalid file type.'
+    end
+  end
+
+  def self.verify_link(amara_link)
+    unless amara_link =~ /^http:\/\/www.amara.org\/en\/videos\/([\w\d]+)\/my\/(\d+)\/?$/
+      raise ArgumentError, 'Invalid link format.'
     end
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,6 @@
 class Video < ActiveRecord::Base
   require 'YoutubeReader'
+  require 'net/http'
 
   attr_accessible :description, :title, :youtube_id, :starred, :duration
   acts_as_taggable
@@ -24,6 +25,16 @@ class Video < ActiveRecord::Base
 
   def youtube_link
     "http://www.youtube.com/embed/#{self.youtube_id}"
+  end
+
+  def amara_link
+    "http://www.amara.org/en/subtitles/editor/#{self.amara_id}/my/"
+  end
+
+  def amara_en_srt
+    link = "http://www.amara.org/en/videos/#{self.amara_id}/en/"
+
+    Video.get_srt_link_from_amara(link)
   end
 
   def fill_missing_fields
@@ -91,5 +102,14 @@ class Video < ActiveRecord::Base
       video.fill_missing_fields
       video.save
     end
+  end
+
+  def self.get_srt_link_from_amara(amara_link)
+    result = Net::HTTP.get_response(URI.parse(amara_link))
+    return nil if [ '404', '403' ].include?(result.code)
+    result = Net::HTTP.get_response(URI.parse(result.header['location'])) if [ '302', '301' ].include?(result.code)
+
+    srt_link_match = /<a href="([^"]*)">SRT<\/a>/.match(result.body)[1]
+    "http://www.amara.org/#{srt_link_match}"
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -40,6 +40,8 @@ class Video < ActiveRecord::Base
         write_attribute(field, youtube_values[field]) unless self[field]
       end
     end
+
+    write_attribute(:amara_id, YoutubeReader::amara_id(self.youtube_id))
   end
 
   def self.recently_translated_videos(time)

--- a/app/views/videos/show/_translate_frame.html.erb
+++ b/app/views/videos/show/_translate_frame.html.erb
@@ -19,7 +19,7 @@
       <div role="tabpanel">
         <div class="tab-content">
           <div role="tabpanel" class="tab-pane fade in active tab-amara" id="tab-amara">
-            <span>If you'd like to use Amara's translation interface, you can use the <b><a href="#">link to the Amara video</a></b>. To earn points, submit your completed Amara link below.</span>
+            <span>If you'd like to use Amara's translation interface, you can use the <b><%= link_to 'link to the Amara video', video.amara_link %></b>. To earn points, submit your completed Amara link below.</span>
 
             <form role="form" class="tab-form">
               <div class="input-group">
@@ -31,7 +31,11 @@
             </form>
           </div>
           <div role="tabpanel" class="tab-pane fade tab-srt" id="tab-srt">
-            <span>If you want to translate offline using an SRT, you can <b><a href="#">download the video's SRT</a></b>. When you're finished translating, just ship it back to us!</span>
+            <% if (srt_link = video.amara_en_srt) %>
+              <span>If you want to translate offline using an SRT, you can <b><%= link_to 'download the video\'s SRT', srt_link %></b>. When you're finished translating, just ship it back to us!</span>
+            <% else %>
+              <span>If you want to translate offline using an SRT, you can use the video above. Unfortunately, there is no English SRT available. When you're finished translating, just ship it back to us!</span>
+            <% end %>
 
             <%= form_tag(video_translation_upload_path(video, translation), :class => 'tab-form', :multipart => true) do %>
               <div class="form-group">

--- a/app/views/videos/show/_translate_frame.html.erb
+++ b/app/views/videos/show/_translate_frame.html.erb
@@ -19,16 +19,16 @@
       <div role="tabpanel">
         <div class="tab-content">
           <div role="tabpanel" class="tab-pane fade in active tab-amara" id="tab-amara">
-            <span>If you'd like to use Amara's translation interface, you can use the <b><%= link_to 'link to the Amara video', video.amara_link %></b>. To earn points, submit your completed Amara link below.</span>
+            <span>If you'd like to use Amara's translation interface, you can use the <b><%= link_to 'link to the Amara video', video.amara_link %></b>. To earn points, submit your published Amara link below.</span>
 
-            <form role="form" class="tab-form">
+            <%= form_tag(video_translation_submit_amara_path(video, translation), :class => 'tab-form', :multipart => true) do %>
               <div class="input-group">
-                <input type="text" class="form-control" placeholder="Copy your Amara link here.">
+                <%= text_field_tag :amara_link, nil, :class => 'form-control', :placeholder => 'Copy your Amara link here.' %>
                 <div class="input-group-btn">
-                  <button type="button" class="btn btn-primary">Submit</button>
+                  <%= submit_tag 'Submit', :class => 'btn btn-primary' %>
                 </div>
               </div>
-            </form>
+            <% end %>
           </div>
           <div role="tabpanel" class="tab-pane fade tab-srt" id="tab-srt">
             <% if (srt_link = video.amara_en_srt) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ KhanBurmese::Application.routes.draw do
     put :toggle_star
     resources :translations do
       post 'upload' => 'translations#upload'
+      post 'submit_amara' => 'translations#submit_amara'
       post 'vote' => 'translations#vote'
       post 'review_mail' => 'translations#review_mail'
     end

--- a/db/migrate/20150414065711_add_amara_id_to_videos.rb
+++ b/db/migrate/20150414065711_add_amara_id_to_videos.rb
@@ -1,0 +1,5 @@
+class AddAmaraIdToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :amara_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150414002745) do
+ActiveRecord::Schema.define(:version => 20150414065711) do
 
   create_table "identities", :force => true do |t|
     t.integer  "user_id"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(:version => 20150414002745) do
     t.datetime "updated_at",                     :null => false
     t.boolean  "starred",     :default => false
     t.integer  "duration"
+    t.string   "amara_id"
   end
 
   create_table "votes", :force => true do |t|

--- a/features/video_translation.feature
+++ b/features/video_translation.feature
@@ -27,7 +27,7 @@ Scenario: Assign video and unassign video.
 Scenario: Translate a video offline.
   When I press "Assign to Me"
   And I press "Translate Offline"
-  Then I should see "download the video's"
+  Then I should see "If you want to translate offline"
   When I upload the file "subtitle.srt" to "srt"
   And I press "Upload"
   Then I should not see "Unassign Me"

--- a/lib/modules/YoutubeReader.rb
+++ b/lib/modules/YoutubeReader.rb
@@ -1,5 +1,7 @@
 module YoutubeReader
   require 'net/http'
+  require 'nokogiri'
+  require 'open-uri'
 
   def self.parse_video(youtube_id, timeout = 5)
     uri = URI.parse(data_link(youtube_id))
@@ -16,6 +18,14 @@ module YoutubeReader
       'description' => data['group']['description'],
       'duration' => Integer(data['group']['duration']['seconds'])
     }
+  end
+
+  def self.amara_id(youtube_id)
+    youtube_url = "\"https://www.youtube.com/watch?v=#{youtube_id}\""
+    video_url = "https://www.amara.org/widget/rpc/jsonp/show_widget?video_url=#{URI::encode(youtube_url)}&is_remote=true"
+    response = Nokogiri::HTML(open(video_url).read)
+
+    /"video_id"[^"]*"([^"]*)"/.match(response.text)[1]
   end
 
   def self.data_link(youtube_id)


### PR DESCRIPTION
A little bit of janky Amara uploading to SRT files. Amara API is a bit complicated, so instead we're collecting SRT file links directly from the video pages. The version is kept internally, so we'll just pull the most recent version for the Myanmar and English SRT translations.

List of changes:
* Stores a local Amara ID for each video after it has been created. Consider moving the `fill_missing_fields` method  to `before_create`.
* Grabs the most recent English SRT from Amara during the show video view. If it does not exist, say so.
* Allows submitting an Amara link that matches a Regex pattern. We use a similar method to grab the most recent Burmese SRT file and store it in our Dropbox folder.

Reviewer: @nalnaji @nishadsingh1