### PR TITLE
Fixes for CodeClimate test coverage reports.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,7 @@ SimpleCov.start 'rails'
 ENV['SKIP_RAILS_ADMIN_INITIALIZER'] = 'false'
 require 'cucumber/rails'
 
-require "codeclimate-test-reporter"
+require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 
 # Capybara defaults to CSS3 selectors rather than XPath.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,6 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 require 'devise'
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
Trivial fix. CodeClimate only processes the first payload, so we remove the call when running RSpec.

Reviewer: @nalnaji