### PR TITLE
Bugfix for users' translated videos.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,9 @@ class User < ActiveRecord::Base
     self.translation_videos.select { |video| not video.translated? }
   end
   def translated_videos
-    self.translation_videos.select { |video| video.translated? }
+    self.translation_videos.select do |video|
+      video.translations.select { |t| t.complete? }.map(&:user).include?(self)
+    end
   end
 
   def reviewed_videos


### PR DESCRIPTION
Bug where a video would show up as translated under a user who did not complete that translation as long as someone else had translated it. Fixed with some questionably long logic. Consider outsourcing some of this to the video model using `translators` and `assignees`.

Reviewer: @nalnaji @jonathanshum