### PR TITLE
Importing for already translated videos.

### DIFF
--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -24,6 +24,10 @@ class Translation < ActiveRecord::Base
   # Maps from status symbol to integer representation for database:
   @@STATUS_TO_INT_HASH = @@STATUS_HASH.invert
 
+  def user
+    super || User.anonymous_user
+  end
+
   def points
     @@POINTS_HASH[self.status_symbol]
   end
@@ -50,6 +54,10 @@ class Translation < ActiveRecord::Base
 
   def reviewed?
     self.net_votes > 0
+  end
+
+  def anonymous_translator?
+    user_id.nil?
   end
 
   def complete

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -87,7 +87,7 @@ class Translation < ActiveRecord::Base
     Translation.verify_link(amara_link)
 
     srt_link = Video.get_srt_link_from_amara(amara_link)
-    raise ArgumentError, 'No SRT published.' unless srt_link
+    raise ArgumentError, "No SRT published for #{video.title}." unless srt_link
 
     self.srt = URI.parse(srt_link)
     self.save
@@ -111,7 +111,7 @@ class Translation < ActiveRecord::Base
   end
 
   def self.verify_link(amara_link)
-    unless amara_link =~ /^http:\/\/www.amara.org\/en\/videos\/([\w\d]+)\/my\/(\d+)\/?$/
+    unless amara_link =~ /^http:\/\/www.amara.org\/en\/videos\/([\w\d]+)\/my(\/(\d+))?\/?$/
       raise ArgumentError, 'Invalid link format.'
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,17 @@ class User < ActiveRecord::Base
     User.all.sort_by { |user| user.points(after) }.reverse
   end
 
+  # Anonymous user object for translations:
+  def self.anonymous_user
+    @@anonymous ||= User.new
+    class << @@anonymous
+      def name
+        'Anonymous'
+      end
+    end
+    @@anonymous
+  end
+
   private
   def capitalize_fields
     write_attribute(:name, name.titleize) if name

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -139,7 +139,13 @@ class Video < ActiveRecord::Base
       video.subject_list.add(row['subject'])
 
       video.fill_missing_fields
-      video.save
+
+      if video.save and row['translated?'] and row['translated?'].downcase != 'false'
+        translation = Translation.new(:video => video)
+
+        link = "http://www.amara.org/en/videos/#{video.amara_id}/my/"
+        translation.upload_amara(link)
+      end
     end
   end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -148,7 +148,8 @@ class Video < ActiveRecord::Base
     return nil if [ '404', '403' ].include?(result.code)
     result = Net::HTTP.get_response(URI.parse(result.header['location'])) if [ '302', '301' ].include?(result.code)
 
-    srt_link_match = /<a href="([^"]*)">SRT<\/a>/.match(result.body)[1]
-    "http://www.amara.org/#{srt_link_match}"
+    srt_link_match = /<a href="([^"]*)">SRT<\/a>/.match(result.body)
+    return nil if srt_link_match.nil?
+    "http://www.amara.org/#{srt_link_match[1]}"
   end
 end

--- a/app/views/videos/translations/_translation_row.html.erb
+++ b/app/views/videos/translations/_translation_row.html.erb
@@ -4,7 +4,10 @@
       <%= render 'videos/translations/vote_actions', :video => video, :translation => translation %>
     </div>
   </td>
-  <td><%= link_to translation.user.name, user_path(translation.user), :class => 'row-title' %></td>
+  <td>
+    <% user_url = translation.anonymous_translator? ? nil : translation.user %>
+    <%= link_to_unless translation.anonymous_translator?, translation.user.name, user_url, :class => 'row-title' %>
+  </td>
   <td><%= translation.time_updated.localtime.strftime("%B %d, %Y at %l:%M") %></td>
   <td>
     <%= link_to 'Download', translation.srt.url(:download => true), :class => 'btn btn-success btn-xs' %>

--- a/public/video/template.csv
+++ b/public/video/template.csv
@@ -1,4 +1,5 @@
-title,youtube_id,description,subject
+title,youtube_id,description,subject,translated?
 Welcome,eDijKSMoVwg,Make your videos in this format.,Math
 Example,_OBlgSz8sSM,A heinous crime of assault and battery.,History
 Top Meryl Streep Performances,m5kjb8xtdho,Meryl Streep's best gigs.,History
+Comparing Decimals 4,FwMYoK1QKso,A video that has already been translated.,Programming,true


### PR DESCRIPTION
Minor bugfixes. Now allows administrators to add a "translated" column to the CSV import. If the field is active, we grab the translation from Amara and add it to the video, with an anonymous translator.

Reviewer: @nalnaji @delicioustoast