### PR TITLE
Removed deprecated permafocus on search bar.

### DIFF
--- a/app/assets/javascripts/videos.js
+++ b/app/assets/javascripts/videos.js
@@ -20,9 +20,6 @@ $(function() {
       return false;
     }
   });
-  $('#search').bind('blur', function(e) {
-    this.focus();
-  });
 });
 
 function starClick(element) {

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag videos_path, :method => 'get', :class => 'form-search', :id => 'video-search' do %>
     <div class="col-lg-6 col-md-5 no-padding">
       <%= text_field_tag :search, nil, {
-        :class => 'form-control', :placeholder => 'Search by video name.', :autocomplete => 'off'
+        :class => 'form-control', :placeholder => 'Search by video name.', :autofocus => true
       } %>
     </div>
 


### PR DESCRIPTION
Permafocus was a workaround for Rails autocomplete. No longer necessary; that feature was removed multiple patches ago. Instead autofocuses on search bar; focus can change later.

Reviewer: @nalnaji